### PR TITLE
Support latest AWS SDK

### DIFF
--- a/autosmush
+++ b/autosmush
@@ -64,7 +64,7 @@
         $total_uncompressed_bytes = 0;
 
         // Get the bucket's contents...
-        $s3      = new AmazonS3(AWS_S3_KEY, AWS_S3_SECRET);
+        $s3      = new AmazonS3(array('key' => AWS_S3_KEY, 'secret' => AWS_S3_SECRET));
         $options = array('prefix' => $bucket_path);
         
         // Check bucket's headers


### PR DESCRIPTION
The latest AWS SDK requires an associative array including 'key' and 'secret', if passing those directly. This change is working for me currently.

Are you still using this, by chance? Are there any other related, client-side performance tools you recommend, beyond the obvious of YSlow, of course. Thanks!
